### PR TITLE
Fix extra batch dimension in classification explainer outputs

### DIFF
--- a/src/myerson/chemprop_explain/myerson.py
+++ b/src/myerson/chemprop_explain/myerson.py
@@ -270,7 +270,7 @@ class MyersonClassExplainer(MyersonExplainer):
         subgraph.to(self.coalition_function.device)
         out = self.coalition_function(subgraph)
         
-        return out.detach().cpu()
+        return out.detach().cpu().squeeze(0)
 
     def calculate_prediction(self) -> torch.Tensor:
         """Calculate the prediction of the GNN for the investigated graph. When 
@@ -282,7 +282,7 @@ class MyersonClassExplainer(MyersonExplainer):
         """
         input = BatchMolGraph([self.molgraph])
         input.to(self.coalition_function.device)
-        return self.coalition_function(input).cpu()
+        return self.coalition_function(input).cpu().squeeze(0)
 
 
 class MyersonSamplingClassExplainer(MyersonSamplingExplainer, MyersonClassExplainer):
@@ -359,7 +359,7 @@ class MyersonSamplingClassExplainer(MyersonSamplingExplainer, MyersonClassExplai
         self.sample_all_mappings()
         pred = self.calculate_prediction()
         nodes_array = np.array(self.grand_coalition)
-        my_values = np.zeros((len(nodes_array), pred.shape[1]), dtype=float)
+        my_values = np.zeros((len(nodes_array), pred.shape[0]), dtype=float)
         self.log.info(f"Calculating sampled Myerson values.")
         for permutation in tqdm(self.permutations_without_random_node,
                               disable=self.disable_tqdm,

--- a/src/myerson/pyg_explain/myerson.py
+++ b/src/myerson/pyg_explain/myerson.py
@@ -347,7 +347,7 @@ class MyersonClassExplainer(MyersonExplainer):
         subgraph = self.subgraph_from_coalition(graph_restricted_coalition, pyg_graph)
         out = self.coalition_function(subgraph.x, subgraph.edge_index, self._batch_var(subgraph))
         
-        return out.detach().cpu()
+        return out.detach().cpu().squeeze(0)
 
     def calculate_prediction(self) -> torch.tensor:
         """Calculate the prediction of the GNN for the investigated graph. When 
@@ -358,7 +358,7 @@ class MyersonClassExplainer(MyersonExplainer):
             float: Prediction.
         """
         return self.coalition_function(self.pyg_graph.x, self.pyg_graph.edge_index,
-                                    self._batch_var(self.pyg_graph)).cpu()
+                                    self._batch_var(self.pyg_graph)).cpu().squeeze(0)
 
 
 class MyersonSamplingClassExplainer(MyersonSamplingExplainer, MyersonClassExplainer):
@@ -438,7 +438,7 @@ class MyersonSamplingClassExplainer(MyersonSamplingExplainer, MyersonClassExplai
         self.sample_all_mappings()
         pred = self.calculate_prediction()
         nodes_array = np.array(self.grand_coalition)
-        my_values = np.zeros((len(nodes_array), pred.shape[1]), dtype=float)
+        my_values = np.zeros((len(nodes_array), pred.shape[0]), dtype=float)
         self.log.info(f"Calculating sampled Myerson values.")
         for permutation in tqdm(self.permutations_without_random_node,
                               disable=self.disable_tqdm,

--- a/src/myerson/pyg_explain/perturbation.py
+++ b/src/myerson/pyg_explain/perturbation.py
@@ -169,7 +169,7 @@ class PerturbationClassExplainer(PerturbationExplainer):
         subgraph = self.subgraph_from_coalition(coalition, pyg_graph)
         out = self.coalition_function(subgraph.x, subgraph.edge_index, self._batch_var(subgraph))
         
-        return out.detach().cpu()
+        return out.detach().cpu().squeeze(0)
 
     def calculate_prediction(self) -> torch.tensor:
         """Calculate the prediction of the GNN for the investigated graph.
@@ -178,4 +178,4 @@ class PerturbationClassExplainer(PerturbationExplainer):
             float: Prediction.
         """
         return self.coalition_function(self.pyg_graph.x, self.pyg_graph.edge_index,
-                                    self._batch_var(self.pyg_graph)).cpu()
+                                    self._batch_var(self.pyg_graph)).cpu().squeeze(0)

--- a/src/myerson/pyg_explain/shapley.py
+++ b/src/myerson/pyg_explain/shapley.py
@@ -220,7 +220,7 @@ class ShapleyClassExplainer(ShapleyExplainer):
         subgraph = self.subgraph_from_coalition(coalition, pyg_graph)
         out = self.coalition_function(subgraph.x, subgraph.edge_index, self._batch_var(subgraph))
         
-        return out.detach().cpu()
+        return out.detach().cpu().squeeze(0)
 
     def calculate_prediction(self) -> torch.tensor:
         """Calculate the prediction of the GNN for the investigated graph.
@@ -229,7 +229,7 @@ class ShapleyClassExplainer(ShapleyExplainer):
             float: Prediction.
         """
         return self.coalition_function(self.pyg_graph.x, self.pyg_graph.edge_index,
-                                    self._batch_var(self.pyg_graph)).cpu()
+                                    self._batch_var(self.pyg_graph)).cpu().squeeze(0)
 
 
 class ShapleySamplingClassExplainer(ShapleySamplingExplainer, ShapleyClassExplainer):
@@ -277,7 +277,7 @@ class ShapleySamplingClassExplainer(ShapleySamplingExplainer, ShapleyClassExplai
         self.sample_all_mappings()
         pred = self.calculate_prediction()
         nodes_array = np.array(self.grand_coalition)
-        sh_values = np.zeros((len(nodes_array), pred.shape[1]), dtype=float)
+        sh_values = np.zeros((len(nodes_array), pred.shape[0]), dtype=float)
         self.log.info(f"Calculating sampled Shapley values.")
         for permutation in tqdm(self.permutations_without_random_node,
                               disable=self.disable_tqdm,


### PR DESCRIPTION
Classification models output a tensor with a batch dimension (e.g., shape `(1, 3)`), which was being preserved when extracting the tensor values. This caused the final explanation arrays to have an unwanted extra dimension, such as `(10, 1, 3)` instead of the expected `(10, 3)`.

This commit fixes the issue by:
- Adding `.squeeze(0)` to `calculate_prediction` and the worth calculation methods across all PyG and Chemprop `ClassExplainer` variants (Myerson, Shapley, Perturbation) to properly drop the batch dimension.
- Updating the pre-allocated array initialization in the `SamplingClassExplainer` variants to use `pred.shape[0]` instead of `pred.shape[1]`, aligning with the newly squeezed prediction shape.